### PR TITLE
fix: エディタが下半分にしか表示されない問題を修正

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -614,25 +614,24 @@ body.resizing * {
   height: 100%;
 }
 
-.editor-pane {
+.editor-cm-pane {
   flex: 1;
   min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-right: 1px solid var(--border);
 }
 
 /* @uiw/react-codemirror のラッパー div */
-.editor-pane > div {
+.editor-cm-pane > div {
   flex: 1;
   min-height: 0;
   display: flex;
   flex-direction: column;
 }
 
-.editor-pane .cm-editor {
+.editor-cm-pane .cm-editor {
   flex: 1;
   min-height: 0;
 }

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -114,7 +114,7 @@ export function Editor({ content, filePath, isDirty, onChange, onNavigate }: Edi
 
       <div className={`editor-body editor-body--${viewMode}`}>
         {(viewMode === "edit" || viewMode === "split") && (
-          <div className="editor-pane">
+          <div className="editor-cm-pane">
             <CodeMirror
               value={content}
               height="100%"


### PR DESCRIPTION
## Summary
- `.editor-pane` CSSクラスが EditorPane（外側）と Editor 内 CodeMirror ラッパー（内側）で重複していた
- `.editor-pane > div` セレクタが TabBar にも `flex: 1` を適用し、上半分を占有していた
- 内側を `.editor-cm-pane` にリネームして衝突を解消

Closes #5